### PR TITLE
Pass app project version to Sonar

### DIFF
--- a/services/build.gradle.kts
+++ b/services/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 sonar {
     properties {
         property("sonar.projectName", "govuk-mobile-android-services")
+        property("sonar.projectVersion", "0.0.1")
         property("sonar.projectKey", "alphagov_govuk-mobile-android-services")
         property("sonar.organization", "alphagov")
         property("sonar.host.url", "https://sonarcloud.io")


### PR DESCRIPTION
# Pass the application project version to Sonar

This was erroneously removed during the `sonor.gradle` conversion so is reinstated here.

This reintroduction however causes the version number to be duplicated, which is not ideal! It is in both `app/build.gradle.kts` and now `services/build.gradle.kts`. However, at this stage it is felt that it's duplication serves as a reminder for when it becomes possible to de-dupe it - see following discussion... 

While it's possible to create a shell script (see below) to get the version number from one of the `build.gradle.kts` files - and then run that script in the other `build.gradle.kts` file, which would remove the duplication, that would simply move the duplication (of the shell script) up a level to the repo level. Where that script would then need to be duplicated in all four of these repos:

- https://github.com/alphagov/govuk-mobile-android-app
- https://github.com/alphagov/govuk-mobile-android-services
- https://github.com/alphagov/govuk-mobile-android-onboarding
- https://github.com/alphagov/govuk-mobile-android-homepage

A better option (in the current modularised state) would be to investigate the centralisation of such values, scripts, GitHub actions etc which already exist across in above four repos. 

### Example shell script

```shell
grep -w '../app/build.gradle.kts' -e 'versionName' | xargs | tr -d 'versionName = '
```

_**Note**: I'm assuming here that the (marketing) versionNumber/projectVersion is effectively the overall app (i.e. the  govuk-mobile-android-app) version and not the version of individual modules._

## JIRA ticket(s)
  - [GOVAPP-462](https://govukverify.atlassian.net/jira/software/c/projects/GOVUKAPP/boards/559?selectedIssue=GOVUKAPP-462)
